### PR TITLE
Create unified figma updater package

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+
+- [x] Design configuration loading that merges figma credentials and Eliza API settings from `figma-updater.config.js`.
+- [x] Reuse the diff extraction pipeline from `figma-diffs` inside the new updater package.
+- [x] Implement clean helpers for reading `.po` translation files and locating code paths.
+- [x] Wrap file replacement logic with logging and robust error handling.
+- [x] Provide a CLI with options to list changes or apply them.
+- [x] Document the new package structure and usage instructions.

--- a/figma-updater.config.js
+++ b/figma-updater.config.js
@@ -1,0 +1,14 @@
+export default {
+  figma: {
+    apiUrl: process.env.FIGMA_API_URL ?? 'https://api.figma.com/v1/files/',
+    token: process.env.FIGMA_TOKEN ?? null,
+  },
+  translations: {
+    path: 'src/locales/ru.po',
+  },
+  eliza: {
+    endpoint: process.env.ELIZA_ENDPOINT ?? '',
+    apiKey: process.env.ELIZA_TOKEN ?? '',
+    model: process.env.ELIZA_MODEL ?? '',
+  },
+};

--- a/figma-updater/README.md
+++ b/figma-updater/README.md
@@ -1,0 +1,72 @@
+# @yandex-id/figma-updater
+
+`@yandex-id/figma-updater` объединяет удобный поиск отличий текстов из Figma и автоматическое применение правок в кодовой базе.
+
+## Возможности
+
+- Получение списка версий макета из Figma.
+- Формирование карты текстовых отличий между двумя версиями макета.
+- Вывод найденных изменений в консоль (режим списка).
+- Автоматическая замена строк в коде на основании `.po` файла с переводами.
+- Поиск подходящего файла через Eliza API, если строка не найдена в переводах.
+
+## Установка
+
+```bash
+npm i --save-dev @yandex-id/figma-updater
+```
+
+## Настройка
+
+Создайте файл `figma-updater.config.js` в корне проекта и укажите ключевые параметры:
+
+```js
+export default {
+  figma: {
+    apiUrl: 'https://api.figma.com/v1/files/',
+    token: process.env.FIGMA_TOKEN,
+  },
+  translations: {
+    // путь до файла переводов относительно корня проекта
+    path: 'src/locales/ru.po',
+  },
+  eliza: {
+    endpoint: process.env.ELIZA_ENDPOINT,
+    apiKey: process.env.ELIZA_TOKEN,
+    model: process.env.ELIZA_MODEL,
+  },
+};
+```
+
+Поля `eliza` необязательны. Если их не указать, поиск файлов будет выполняться только по `.po` файлу.
+
+## Использование
+
+```bash
+npx @yandex-id/figma-updater <figma-url> <old-version-id> <new-version-id>
+```
+
+- `<figma-url>` — ссылка на макет в Figma.
+- `<old-version-id>` и `<new-version-id>` — идентификаторы версий макета. Если их не указать, инструмент выведет список доступных версий.
+
+Для просмотра только списка изменений без правок добавьте флаг `--list`:
+
+```bash
+npx @yandex-id/figma-updater <figma-url> <old-version-id> <new-version-id> --list
+```
+
+## Скрипты npm
+
+- `npm run build` — сборка библиотеки с помощью `@yandex-id/buildx`.
+- `npm run lint:tsc` — проверка типов.
+- `npm run prepare` — автосборка перед публикацией.
+
+## Переменные окружения
+
+- `FIGMA_TOKEN` — токен доступа к Figma API (используется, если не задан в конфиге).
+- `FIGMA_API_URL` — базовый URL API Figma (по умолчанию `https://api.figma.com/v1/files/`).
+- `ELIZA_ENDPOINT`, `ELIZA_TOKEN`, `ELIZA_MODEL` — параметры Eliza API (если не указаны в конфиге).
+
+## Лицензия
+
+UNLICENSED

--- a/figma-updater/bin/figma-updater.js
+++ b/figma-updater/bin/figma-updater.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+function start() {
+  return import('../lib/es/cli.mjs');
+}
+
+start();

--- a/figma-updater/buildx.config.ts
+++ b/figma-updater/buildx.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@yandex-id/buildx';
+
+export default defineConfig({
+  cleanDir: './lib',
+  input: {
+    index: 'src/index.ts',
+    cli: 'src/cli.ts',
+  },
+  output: [
+    {
+      format: 'es',
+    },
+    {
+      format: 'cjs',
+    },
+  ],
+  builtin: {
+    dts: {
+      tsconfigFile: './tsconfig.lib.json',
+    },
+    swc: {
+      tsconfigFile: './tsconfig.lib.json',
+      jsc: {
+        externalHelpers: true,
+      },
+    },
+  },
+});

--- a/figma-updater/eslint.config.ts
+++ b/figma-updater/eslint.config.ts
@@ -1,0 +1,8 @@
+import { configs, defineConfig } from '@yandex-id/eslint-config';
+
+export default defineConfig(configs.recommended, {
+  ignores: ['lib/**/*'],
+  rules: {
+    'ascii/valid-name': 'off',
+  },
+});

--- a/figma-updater/package.json
+++ b/figma-updater/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@yandex-id/figma-updater",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "build": "buildx",
+    "ci:build": "npm run build",
+    "ci:lint": "npm run lint:tsc && npm run lintstaged",
+    "lint:tsc": "tsc -b --noEmit",
+    "lintstaged": "lint-staged --vcs-adapter @yandex-int/si.ci.lint-staged-arc-workflow --no-stash",
+    "prepare": "npm run build"
+  },
+  "bin": {
+    "figma-updater": "./bin/figma-updater.js"
+  },
+  "main": "./lib/cjs/index.cjs",
+  "module": "./lib/es/index.mjs",
+  "types": "./lib/types/index.d.ts",
+  "files": [
+    "lib",
+    "README.md"
+  ],
+  "dependencies": {
+    "@figma/rest-api-spec": "0.33.0",
+    "cac": "6.7.14",
+    "consola": "3.4.2",
+    "dotenv": "16.4.7"
+  },
+  "devDependencies": {
+    "@types/node": "22.12.0",
+    "typescript": "5.9.2",
+    "@yandex-id/buildx": "0.1.0",
+    "@yandex-id/eslint-config": "1.0.0",
+    "@yandex-id/prettier-config": "2.0.0",
+    "@yandex-int/lint-staged": "0.0.1",
+    "@yandex-int/si.ci.lint-staged-arc-workflow": "1.2.1",
+    "eslint": "9.23.0",
+    "prettier": "3.5.3",
+    "ts-node": "10.9.2",
+    "tsx": "4.20.4"
+  }
+}

--- a/figma-updater/prettier.config.js
+++ b/figma-updater/prettier.config.js
@@ -1,0 +1,3 @@
+import { configs, defineConfig } from '@yandex-id/prettier-config';
+
+export default defineConfig(configs.recommended);

--- a/figma-updater/src/cli.ts
+++ b/figma-updater/src/cli.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+
+import { cac } from 'cac';
+
+import { logger } from './logger.js';
+import { run } from './index.js';
+
+const cli = cac('figma-updater');
+
+cli
+  .command('<figmaUrl> [oldVersion] [newVersion]')
+  .option('--list', 'Только показать список изменений без применения правок')
+  .action(async (figmaUrl: string, oldVersion?: string, newVersion?: string, options?: { list?: boolean }) => {
+    try {
+      await run({ figmaUrl, oldVersion, newVersion, listOnly: options?.list });
+    } catch (error) {
+      logger.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+cli.help();
+cli.version('0.1.0');
+
+cli.parse();

--- a/figma-updater/src/index.ts
+++ b/figma-updater/src/index.ts
@@ -1,0 +1,75 @@
+import { logger } from './logger.js';
+import type { DiffMapping, GetDiffsOptions, LoadedConfig } from './types.js';
+import { loadConfig } from './modules/config.js';
+import { getTextDiffsMapping } from './modules/diff-mapping.js';
+import { getFigmaVersionsList } from './modules/figma-api.js';
+import { applyDiffs } from './modules/file-updater.js';
+
+export interface RunOptions extends GetDiffsOptions {
+  cwd?: string;
+  listOnly?: boolean;
+}
+
+async function ensureVersions(
+  config: LoadedConfig,
+  figmaUrl: string,
+  oldVersion?: string,
+  newVersion?: string,
+): Promise<{ diffs?: DiffMapping; versions?: Awaited<ReturnType<typeof getFigmaVersionsList>> } | undefined> {
+  if (!oldVersion || !newVersion) {
+    const versions = await getFigmaVersionsList(config, figmaUrl);
+
+    if (!versions) {
+      logger.error('Версии макета не найдены.');
+      return undefined;
+    }
+
+    logger.success('Доступные версии:');
+    versions.forEach((version) => {
+      logger.info(`${version.id} ${version.label ?? ''}`.trim());
+      logger.info(new Date(version.created_at).toLocaleString());
+      logger.info(version.user.handle);
+      logger.info('');
+    });
+
+    return { versions };
+  }
+
+  const diffs = await getTextDiffsMapping(config, figmaUrl, oldVersion, newVersion);
+
+  return { diffs };
+}
+
+export async function getDiffs(options: GetDiffsOptions, cwd?: string): Promise<DiffMapping | undefined> {
+  const config = await loadConfig(cwd);
+  const result = await ensureVersions(config, options.figmaUrl, options.oldVersion, options.newVersion);
+
+  return result?.diffs;
+}
+
+export async function run(options: RunOptions) {
+  const { figmaUrl, oldVersion, newVersion, listOnly, cwd } = options;
+  const config = await loadConfig(cwd);
+  const result = await ensureVersions(config, figmaUrl, oldVersion, newVersion);
+
+  if (!result?.diffs) {
+    return;
+  }
+
+  logger.info(`Найдено изменений: ${result.diffs.length}`);
+
+  result.diffs.forEach((pair) => {
+    const [from, to] = Object.entries(pair)[0];
+    logger.info(`• "${from}" → "${to}"`);
+  });
+
+  if (listOnly) {
+    logger.info('Режим просмотра: файлы не будут изменены.');
+    return;
+  }
+
+  await applyDiffs({ diffs: result.diffs, config });
+}
+
+export { loadConfig };
+export type { DiffMapping };

--- a/figma-updater/src/logger.ts
+++ b/figma-updater/src/logger.ts
@@ -1,0 +1,20 @@
+import { createConsola } from 'consola';
+
+export const IS_TTY = process.stdout.isTTY && !process.env.CI;
+
+export const logger = createConsola();
+
+export function clearLine() {
+  process.stdout.clearLine(0);
+  process.stdout.cursorTo(0);
+}
+
+export function writeLine(output: string) {
+  clearLine();
+
+  if (output.length < process.stdout.columns) {
+    process.stdout.write(output);
+  } else {
+    process.stdout.write(output.substring(0, process.stdout.columns - 1));
+  }
+}

--- a/figma-updater/src/modules/config.ts
+++ b/figma-updater/src/modules/config.ts
@@ -1,0 +1,50 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { FigmaUpdaterConfig, LoadedConfig } from '../types.js';
+
+const DEFAULTS: FigmaUpdaterConfig = {
+  figma: {
+    apiUrl: process.env.FIGMA_API_URL ?? 'https://api.figma.com/v1/files/',
+    token: process.env.FIGMA_TOKEN ?? null,
+  },
+  translations: {
+    path: 'src/locales/ru.po',
+  },
+};
+
+async function importConfig(configPath: string): Promise<Partial<FigmaUpdaterConfig> | null> {
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  const module = await import(pathToFileURL(configPath).href);
+
+  return (module.default ?? module) as Partial<FigmaUpdaterConfig>;
+}
+
+export async function loadConfig(cwd = process.cwd()): Promise<LoadedConfig> {
+  const configPath = path.resolve(cwd, 'figma-updater.config.js');
+  const userConfig = await importConfig(configPath);
+
+  const figmaConfig = {
+    ...DEFAULTS.figma,
+    ...userConfig?.figma,
+    token: userConfig?.figma?.token ?? DEFAULTS.figma.token ?? null,
+  };
+
+  const translationsConfig = {
+    ...DEFAULTS.translations,
+    ...userConfig?.translations,
+  };
+
+  const elizaConfig = userConfig?.eliza;
+
+  return {
+    figma: figmaConfig,
+    translations: translationsConfig,
+    eliza: elizaConfig,
+    rootDir: cwd,
+  };
+}

--- a/figma-updater/src/modules/diff-mapping.ts
+++ b/figma-updater/src/modules/diff-mapping.ts
@@ -1,0 +1,76 @@
+import { type Node, type TextNode } from '@figma/rest-api-spec';
+
+import type { DiffMapping, LoadedConfig } from '../types.js';
+import { getFigmaDocument } from './figma-api.js';
+
+type NodeWithChildren = Extract<Node, { children: any[] }>;
+type NodeMap = Record<string, Node>;
+
+function isNodeWithChildren(node: Node): node is NodeWithChildren {
+  return 'children' in node && Array.isArray(node.children) && node.children.length > 0;
+}
+
+function buildNodeMap(node: Node, map: NodeMap) {
+  map[node.id] = node;
+  if (isNodeWithChildren(node)) {
+    for (const child of node.children) {
+      buildNodeMap(child as Node, map);
+    }
+  }
+}
+
+function extractText(node: Node): string | null {
+  if (node.type !== 'TEXT') {
+    return null;
+  }
+
+  return ((node as TextNode).characters ?? '').trim();
+}
+
+export async function getTextDiffsMapping(
+  config: LoadedConfig,
+  url: string,
+  versionOld: string,
+  versionNew: string,
+): Promise<DiffMapping> {
+  const [oldDoc, newDoc] = await Promise.all([
+    getFigmaDocument(config, url, versionOld),
+    getFigmaDocument(config, url, versionNew),
+  ]);
+
+  const newMap: NodeMap = {};
+
+  buildNodeMap(newDoc.document, newMap);
+
+  const changes: DiffMapping = [];
+  const seen = new Set<string>();
+
+  function traverseAndCompare(oldNode: Node) {
+    const oldText = extractText(oldNode);
+
+    if (oldText && oldText.length > 0) {
+      const match = newMap[oldNode.id];
+
+      if (match) {
+        const newText = extractText(match);
+
+        if (newText && newText.length > 0 && oldText !== newText && !seen.has(oldText)) {
+          seen.add(oldText);
+          changes.push({
+            [oldText]: newText,
+          });
+        }
+      }
+    }
+
+    if (isNodeWithChildren(oldNode)) {
+      for (const child of oldNode.children) {
+        traverseAndCompare(child as Node);
+      }
+    }
+  }
+
+  traverseAndCompare(oldDoc.document);
+
+  return changes;
+}

--- a/figma-updater/src/modules/eliza.ts
+++ b/figma-updater/src/modules/eliza.ts
@@ -1,0 +1,107 @@
+import type { LoadedConfig } from '../types.js';
+import type { TranslationsMap } from './translations.js';
+
+interface ElizaResponse {
+  response?: {
+    choices?: Array<{
+      message?: {
+        content?: string;
+      };
+    }>;
+  };
+}
+
+function formatTranslations(translations: TranslationsMap): Record<string, string> {
+  const formatted: Record<string, string> = {};
+
+  for (const [text, locations] of Object.entries(translations)) {
+    formatted[text] = locations.join(', ');
+  }
+
+  return formatted;
+}
+
+function buildPrompt(oldText: string, translations: TranslationsMap): string {
+  return `Please search through all the string values of the following JSON object and identify the file path where the string "${oldText}" is present.
+
+  The JSON maps localized strings to file references. File references use the PO format "path:line" and multiple references can exist for a single string (comma separated).
+
+  Rules:
+  - Match must be exact ignoring punctuation, spaces, dashes or Unicode symbol variants.
+  - Do not match if additional words are present or the meaning changes.
+  - Return all exact or relaxed matches. If nothing fits, respond with {"codePath": "None"}.
+
+  Respond strictly as JSON: {"codePath": "<value>"}.
+
+  JSON object:
+  ${JSON.stringify(formatTranslations(translations), null, 2)}
+  `;
+}
+
+export async function findCodePathWithEliza(
+  config: LoadedConfig,
+  oldText: string,
+  translations: TranslationsMap,
+): Promise<string | null> {
+  const eliza = config.eliza;
+
+  if (!eliza || !eliza.endpoint || !eliza.apiKey || !eliza.model) {
+    return null;
+  }
+
+  const body = {
+    model: eliza.model,
+    messages: [
+      {
+        role: 'user',
+        content: buildPrompt(oldText, translations),
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'code_path_response',
+        schema: {
+          type: 'object',
+          properties: {
+            codePath: { type: 'string' },
+          },
+          required: ['codePath'],
+          additionalProperties: false,
+        },
+      },
+    },
+  };
+
+  const response = await fetch(eliza.endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `OAuth ${eliza.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as ElizaResponse;
+  const content = data.response?.choices?.[0]?.message?.content;
+
+  if (!content) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { codePath?: string };
+
+    if (!parsed.codePath || parsed.codePath === 'None') {
+      return null;
+    }
+
+    return parsed.codePath;
+  } catch {
+    return null;
+  }
+}

--- a/figma-updater/src/modules/figma-api.ts
+++ b/figma-updater/src/modules/figma-api.ts
@@ -1,0 +1,83 @@
+import {
+  type GetFileResponse,
+  type GetFileVersionsResponse,
+  type Version,
+} from '@figma/rest-api-spec';
+
+import type { LoadedConfig } from '../types.js';
+
+function ensureTrailingSlash(input: string): string {
+  return input.endsWith('/') ? input : `${input}/`;
+}
+
+function extractFileKey(url: string): string {
+  const fileKeyMatch = url.match(/figma\.com\/(?:file|design)\/([a-zA-Z0-9]+)\//);
+
+  if (!fileKeyMatch) {
+    throw new Error('Неверный формат URL Figma');
+  }
+
+  return fileKeyMatch[1];
+}
+
+async function figmaRequest(config: LoadedConfig, url: string, path: string): Promise<Response> {
+  const { figma } = config;
+  const headers: Record<string, string> = {};
+
+  if (figma.token) {
+    headers['X-FIGMA-TOKEN'] = figma.token;
+  }
+
+  const fileKey = extractFileKey(url);
+  const apiUrl = ensureTrailingSlash(figma.apiUrl);
+
+  const response = await fetch(`${apiUrl}${fileKey}${path}`, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Ошибка при запросе к Figma API: ${response.status} ${response.statusText}`);
+  }
+
+  return response;
+}
+
+function isFileResponse(payload: unknown): payload is GetFileResponse {
+  return typeof payload === 'object' && payload !== null && 'document' in payload;
+}
+
+function isVersionsResponse(payload: unknown): payload is GetFileVersionsResponse {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'versions' in payload &&
+    Array.isArray((payload as { versions?: Version[] }).versions)
+  );
+}
+
+export async function getFigmaDocument(
+  config: LoadedConfig,
+  url: string,
+  versionId: string,
+): Promise<GetFileResponse> {
+  const response = await figmaRequest(config, url, `?version=${versionId}`);
+  const data = await response.json();
+
+  if (!isFileResponse(data)) {
+    throw new Error('Неверный формат ответа от Figma API');
+  }
+
+  return data;
+}
+
+export async function getFigmaVersionsList(
+  config: LoadedConfig,
+  url: string,
+): Promise<Version[] | null> {
+  const response = await figmaRequest(config, url, '/versions');
+  const data = await response.json();
+
+  if (!isVersionsResponse(data)) {
+    throw new Error('Неверный формат ответа от Figma API');
+  }
+
+  return data.versions && data.versions.length > 0 ? data.versions : null;
+}

--- a/figma-updater/src/modules/file-updater.ts
+++ b/figma-updater/src/modules/file-updater.ts
@@ -1,0 +1,105 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { logger } from '../logger.js';
+import type { ApplyDiffsOptions } from '../types.js';
+import { findCodePathWithEliza } from './eliza.js';
+import { loadTranslations, type TranslationsMap } from './translations.js';
+
+async function replaceInFile(filePath: string, oldText: string, newText: string): Promise<boolean> {
+  const content = await readFile(filePath, 'utf8');
+
+  if (!content.includes(oldText)) {
+    return false;
+  }
+
+  const updated = content.replace(oldText, newText);
+
+  await writeFile(filePath, updated, 'utf8');
+
+  return true;
+}
+
+function normalizeLocations(locations: string[] | undefined): string[] {
+  if (!locations || locations.length === 0) {
+    return [];
+  }
+
+  return locations.filter(Boolean);
+}
+
+function resolvePath(rootDir: string, codePath: string): string {
+  const [relativePath] = codePath.split(':');
+
+  return path.resolve(rootDir, relativePath);
+}
+
+async function resolveCandidatePaths(
+  config: ApplyDiffsOptions['config'],
+  oldText: string,
+  translations: TranslationsMap,
+): Promise<string[]> {
+  const knownLocations = normalizeLocations(translations[oldText]);
+
+  if (knownLocations.length > 0) {
+    return knownLocations;
+  }
+
+  const suggested = await findCodePathWithEliza(config, oldText, translations);
+
+  if (!suggested) {
+    return [];
+  }
+
+  logger.info(`Eliza API подсказала путь: ${suggested}`);
+
+  return [suggested];
+}
+
+export async function applyDiffs({ diffs, config }: ApplyDiffsOptions) {
+  let translations: TranslationsMap;
+
+  try {
+    translations = await loadTranslations(config);
+  } catch (error) {
+    logger.error(`Не удалось прочитать файл переводов: ${(error as Error).message}`);
+    return;
+  }
+
+  for (const pair of diffs) {
+    const [oldText, newText] = Object.entries(pair)[0];
+
+    if (!oldText || !newText) {
+      continue;
+    }
+
+    const candidates = await resolveCandidatePaths(config, oldText, translations);
+
+    if (candidates.length === 0) {
+      logger.warn(`Не удалось найти путь в переводах для строки: "${oldText}"`);
+      continue;
+    }
+
+    let applied = false;
+
+    for (const candidate of candidates) {
+      const targetPath = resolvePath(config.rootDir, candidate);
+
+      try {
+        const success = await replaceInFile(targetPath, oldText, newText);
+
+        if (success) {
+          logger.success(`Файл обновлен: ${targetPath}`);
+          applied = true;
+          break;
+        }
+      } catch (error) {
+        logger.error(`Ошибка при обновлении файла ${targetPath}: ${(error as Error).message}`);
+      }
+    }
+
+    if (!applied) {
+      logger.warn(`Строка "${oldText}" не найдена в указанных файлах.`);
+    }
+  }
+}

--- a/figma-updater/src/modules/translations.ts
+++ b/figma-updater/src/modules/translations.ts
@@ -1,0 +1,91 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { LoadedConfig } from '../types.js';
+
+export type TranslationsMap = Record<string, string[]>;
+
+function parsePoString(input: string): string {
+  const match = input.match(/"(.*)"/);
+
+  if (!match) {
+    return '';
+  }
+
+  return match[1].replace(/\\n/g, '\n');
+}
+
+export function parsePo(content: string): TranslationsMap {
+  const result: TranslationsMap = {};
+  const lines = content.split(/\r?\n/);
+
+  let pendingLocations: string[] = [];
+  let collecting = false;
+  let buffer = '';
+
+  const flush = () => {
+    if (!collecting) {
+      return;
+    }
+
+    if (buffer.length > 0) {
+      if (!result[buffer]) {
+        result[buffer] = [];
+      }
+
+      result[buffer].push(...pendingLocations);
+    }
+
+    collecting = false;
+    buffer = '';
+    pendingLocations = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith('#:')) {
+      pendingLocations = line
+        .slice(2)
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+      continue;
+    }
+
+    if (line.startsWith('msgid')) {
+      flush();
+      continue;
+    }
+
+    if (line.startsWith('msgstr')) {
+      flush();
+      collecting = true;
+      buffer = parsePoString(line);
+      if (!buffer) {
+        buffer = '';
+      }
+      continue;
+    }
+
+    if (collecting) {
+      if (line.startsWith('"')) {
+        buffer += parsePoString(line);
+        continue;
+      }
+
+      flush();
+    }
+  }
+
+  flush();
+
+  return result;
+}
+
+export async function loadTranslations(config: LoadedConfig): Promise<TranslationsMap> {
+  const translationsPath = path.resolve(config.rootDir, config.translations.path);
+  const content = await readFile(translationsPath, 'utf8');
+
+  return parsePo(content);
+}

--- a/figma-updater/src/types.ts
+++ b/figma-updater/src/types.ts
@@ -1,0 +1,46 @@
+import type { Version } from '@figma/rest-api-spec';
+
+export type DiffMapping = Array<Record<string, string>>;
+
+export interface FigmaConfig {
+  apiUrl: string;
+  token: string | null;
+}
+
+export interface ElizaConfig {
+  endpoint: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface TranslationsConfig {
+  path: string;
+}
+
+export interface FigmaUpdaterConfig {
+  figma: FigmaConfig;
+  eliza?: ElizaConfig;
+  translations: TranslationsConfig;
+}
+
+export interface LoadedConfig extends FigmaUpdaterConfig {
+  rootDir: string;
+}
+
+export interface VersionInfo {
+  id: Version['id'];
+  label?: Version['label'];
+  createdAt: string;
+  author: string;
+}
+
+export interface GetDiffsOptions {
+  figmaUrl: string;
+  oldVersion?: string;
+  newVersion?: string;
+}
+
+export interface ApplyDiffsOptions {
+  diffs: DiffMapping;
+  config: LoadedConfig;
+}

--- a/figma-updater/tsconfig.base.json
+++ b/figma-updater/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "noEmit": true,
+
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
+
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true
+  }
+}

--- a/figma-updater/tsconfig.json
+++ b/figma-updater/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/figma-updater/tsconfig.lib.json
+++ b/figma-updater/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.lib.tsbuildinfo",
+    "declaration": true,
+    "declarationDir": "./lib/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "downlevelIteration": true
+  },
+  "include": ["src", "index.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add a combined figma-updater package that reuses the figma diff pipeline and applies updates via translation mappings and optional Eliza fallback
- expose a polished CLI with a --list option and package metadata mirroring the original figma-diffs setup
- document configuration expectations alongside a filled-out TODO checklist and sample config file

## Testing
- not run (requires private dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d9935ab4d083319b793c82ccc4d864