### PR TITLE
Chunk Eliza API requests to avoid fetch failures

### DIFF
--- a/figma-updater/src/core/eliza-client.ts
+++ b/figma-updater/src/core/eliza-client.ts
@@ -2,6 +2,8 @@ import type { ElizaConfig } from '../config/types.js';
 import { logError } from '../logger.js';
 import type { TranslationsMap } from './translation-catalog.js';
 
+const PROMPT_CHUNK_SIZE = 200;
+
 interface ElizaResponse {
   response?: {
     choices?: Array<{
@@ -12,11 +14,25 @@ interface ElizaResponse {
   };
 }
 
+function normalizeLocations(locations: string[] | undefined): string[] {
+  if (!locations || locations.length === 0) {
+    return [];
+  }
+
+  return locations.filter(Boolean);
+}
+
 function formatTranslations(translations: TranslationsMap): Record<string, string> {
   const formatted: Record<string, string> = {};
 
   for (const [text, locations] of Object.entries(translations)) {
-    formatted[text] = locations.join(', ');
+    const normalized = normalizeLocations(locations);
+
+    if (normalized.length === 0) {
+      continue;
+    }
+
+    formatted[text] = normalized.join(', ');
   }
 
   return formatted;
@@ -39,6 +55,66 @@ ${JSON.stringify(formatTranslations(translations), null, 2)}
 `;
 }
 
+function chunkTranslations(translations: TranslationsMap): TranslationsMap[] {
+  const entries = Object.entries(translations)
+    .map(([text, locations]) => [text, normalizeLocations(locations)] as const)
+    .filter(([, locations]) => locations.length > 0);
+
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const chunks: TranslationsMap[] = [];
+
+  for (let index = 0; index < entries.length; index += PROMPT_CHUNK_SIZE) {
+    const slice = entries.slice(index, index + PROMPT_CHUNK_SIZE);
+    const chunk: TranslationsMap = {};
+
+    for (const [text, locations] of slice) {
+      chunk[text] = locations;
+    }
+
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+type PromptResult = string | undefined | null;
+
+interface FetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+}
+
+function buildRequestBody(model: string, prompt: string) {
+  return {
+    model,
+    messages: [
+      {
+        role: 'user' as const,
+        content: prompt,
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'code_path_response',
+        schema: {
+          type: 'object',
+          properties: {
+            codePath: { type: 'string' },
+          },
+          required: ['codePath'],
+          additionalProperties: false,
+        },
+      },
+    },
+  };
+}
+
 export class ElizaClient {
   constructor(private readonly options: ElizaConfig | undefined) {}
 
@@ -47,45 +123,58 @@ export class ElizaClient {
       return null;
     }
 
-    const body = {
-      model: this.options.model,
-      messages: [
-        {
-          role: 'user' as const,
-          content: buildPrompt(oldText, translations),
-        },
-      ],
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          name: 'code_path_response',
-          schema: {
-            type: 'object',
-            properties: {
-              codePath: { type: 'string' },
-            },
-            required: ['codePath'],
-            additionalProperties: false,
-          },
-        },
-      },
-    };
+    const { endpoint, apiKey, model } = this.options;
+    const chunks = chunkTranslations(translations);
 
-    const response = await (async () => {
-      try {
-        return await fetch(this.options.endpoint, {
-          method: 'POST',
-          headers: {
-            Authorization: `OAuth ${this.options.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(body),
-        });
-      } catch (error) {
-        logError(error, { context: 'Сбой запроса к Eliza API' });
+    if (chunks.length === 0) {
+      return null;
+    }
+
+    for (const chunk of chunks) {
+      const prompt = buildPrompt(oldText, chunk);
+      const result = await this.sendPrompt({ endpoint, apiKey, model, prompt });
+
+      if (result === null) {
         return null;
       }
-    })();
+
+      if (typeof result === 'string') {
+        return result;
+      }
+    }
+
+    return null;
+  }
+
+  private async performRequest(
+    endpoint: string,
+    apiKey: string,
+    body: unknown,
+  ): Promise<FetchResponse | null> {
+    try {
+      return (await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `OAuth ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })) as FetchResponse;
+    } catch (error) {
+      logError(error, { context: 'Сбой запроса к Eliza API' });
+      return null;
+    }
+  }
+
+  private async sendPrompt(options: {
+    endpoint: string;
+    apiKey: string;
+    model: string;
+    prompt: string;
+  }): Promise<PromptResult> {
+    const { endpoint, apiKey, model, prompt } = options;
+    const body = buildRequestBody(model, prompt);
+    const response = await this.performRequest(endpoint, apiKey, body);
 
     if (!response) {
       return null;
@@ -99,18 +188,26 @@ export class ElizaClient {
       return null;
     }
 
-    const data = (await response.json()) as ElizaResponse;
+    let data: ElizaResponse;
+
+    try {
+      data = (await response.json()) as ElizaResponse;
+    } catch (error) {
+      logError(error, { context: 'Не удалось прочитать ответ Eliza API' });
+      return null;
+    }
+
     const content = data.response?.choices?.[0]?.message?.content;
 
     if (!content) {
-      return null;
+      return undefined;
     }
 
     try {
       const parsed = JSON.parse(content) as { codePath?: string };
 
       if (!parsed.codePath || parsed.codePath === 'None') {
-        return null;
+        return undefined;
       }
 
       return parsed.codePath;


### PR DESCRIPTION
## Summary
- split the translation catalogue into smaller batches before calling the Eliza API so the payload no longer exceeds the service limits
- refactor the Eliza client to share prompt/request helpers and log JSON parsing issues explicitly

## Testing
- npm run lint:tsc *(fails: missing workspace dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da8608b45083318ab7468da2d296aa