### PR TITLE
refactor: flatten CLI prompts location

### DIFF
--- a/src/cli-prompts.ts
+++ b/src/cli-prompts.ts
@@ -1,6 +1,6 @@
 import prompts from 'prompts';
 
-import type { VersionInfo } from '../types.js';
+import type { VersionInfo } from './types.js';
 
 const onCancel = () => {
   throw new Error('Операция отменена пользователем.');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { cac } from 'cac';
 
 import { logError, logger } from './logger.js';
 import { run, listVersions } from './index.js';
-import { promptForDirectory, promptForFigmaUrl, promptForVersions } from './cli/prompts.js';
+import { promptForDirectory, promptForFigmaUrl, promptForVersions } from './cli-prompts.js';
 
 interface CliFlags {
   list?: boolean;


### PR DESCRIPTION
## Summary
- move the CLI prompts helper out of its single-file folder and adjust imports accordingly

## Testing
- npm run lint:tsc *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68dbc5c13b6083319d96ee6a730cf7d4