### PR TITLE
Refactor types usage and streamline logger

### DIFF
--- a/src/cli-prompts.ts
+++ b/src/cli-prompts.ts
@@ -1,6 +1,6 @@
 import prompts from 'prompts';
 
-import type { VersionInfo } from './types.js';
+import type { VersionInfo, VersionSelectionResult } from './types.js';
 
 const onCancel = () => {
   throw new Error('Операция отменена пользователем.');
@@ -21,11 +21,6 @@ export async function promptForFigmaUrl(initial?: string): Promise<string> {
   );
 
   return figmaUrl;
-}
-
-export interface VersionSelectionResult {
-  oldVersion: string;
-  newVersion: string;
 }
 
 function formatVersion(version: VersionInfo): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,14 +6,7 @@ import { cac } from 'cac';
 import { logError, logger } from './logger.js';
 import { run, listVersions } from './index.js';
 import { promptForDirectory, promptForFigmaUrl, promptForVersions } from './cli-prompts.js';
-
-interface CliFlags {
-  list?: boolean;
-  dir?: string;
-  old?: string;
-  new?: string;
-  cwd?: string;
-}
+import type { CliFlags } from './types.js';
 
 const cli = cac('texts-updater-by-figma');
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import type { FigmaUpdaterConfig, LoadedConfig } from './types.js';
+import type { FigmaUpdaterConfig, LoadConfigOptions, LoadedConfig } from './types.js';
 
 export const DEFAULT_TRANSLATIONS_PATH = 'src/locales/ru.po';
 
@@ -15,18 +15,6 @@ export const DEFAULT_CONFIG: FigmaUpdaterConfig = {
     path: DEFAULT_TRANSLATIONS_PATH,
   },
 };
-
-export interface LoadConfigOptions {
-  cwd?: string;
-  /**
-   * Relative path to the configuration file. Defaults to `texts-updater-by-figma.config.js`.
-   */
-  configFile?: string;
-  /**
-   * Override the directory where files will be updated.
-   */
-  targetRoot?: string;
-}
 
 async function importConfig(configPath: string): Promise<Partial<FigmaUpdaterConfig> | null> {
   if (!existsSync(configPath)) {

--- a/src/core/eliza-client.ts
+++ b/src/core/eliza-client.ts
@@ -1,18 +1,8 @@
-import type { ElizaConfig } from '../types.js';
+import type { ElizaConfig, ElizaResponse, FetchResponse, PromptResult } from '../types.js';
 import { logError } from '../logger.js';
 import type { TranslationsMap } from './translation-catalog.js';
 
 const PROMPT_CHUNK_SIZE = 200;
-
-interface ElizaResponse {
-  response?: {
-    choices?: Array<{
-      message?: {
-        content?: string;
-      };
-    }>;
-  };
-}
 
 function normalizeLocations(locations: string[] | undefined): string[] {
   if (!locations || locations.length === 0) {
@@ -75,15 +65,6 @@ function chunkTranslations(translations: TranslationsMap): TranslationsMap[] {
   }
 
   return chunks;
-}
-
-type PromptResult = string[] | undefined | null;
-
-interface FetchResponse {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  json(): Promise<unknown>;
 }
 
 function buildRequestBody(model: string, prompt: string) {

--- a/src/core/file-rewriter.ts
+++ b/src/core/file-rewriter.ts
@@ -3,15 +3,9 @@ import path from 'node:path';
 
 import levenshtein from 'fast-levenshtein';
 
-import type { DiffMapping, LoadedConfig } from '../types.js';
+import type { DiffMapping, FileRewriterOptions, ReplacementCandidate } from '../types.js';
 import { logError, logger } from '../logger.js';
-import { ElizaClient } from './eliza-client.js';
-import { TranslationCatalog, type TranslationsMap } from './translation-catalog.js';
-
-interface ReplacementCandidate {
-  codePath: string;
-  searchText: string;
-}
+import type { TranslationsMap } from './translation-catalog.js';
 
 const MAX_LEVENSHTEIN_DISTANCE = 4;
 
@@ -38,12 +32,6 @@ function normalizeLocations(locations: string[] | undefined): string[] {
 function resolvePath(rootDir: string, codePath: string): string {
   const [relativePath] = codePath.split(':');
   return path.resolve(rootDir, relativePath);
-}
-
-export interface FileRewriterOptions {
-  config: LoadedConfig;
-  translations: TranslationCatalog;
-  eliza: ElizaClient;
 }
 
 export class FileRewriter {

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -1,15 +1,9 @@
-import type { DiffMapping, LoadedConfig, VersionInfo } from '../types.js';
+import type { BuildDiffOptions, DiffMapping, LoadedConfig, VersionInfo } from '../types.js';
 import { DiffBuilder } from './diff-builder.js';
 import { ElizaClient } from './eliza-client.js';
 import { FigmaClient } from './figma-client.js';
 import { FileRewriter } from './file-rewriter.js';
 import { TranslationCatalog } from './translation-catalog.js';
-
-export interface BuildDiffOptions {
-  figmaUrl: string;
-  oldVersion: string;
-  newVersion: string;
-}
 
 export class FigmaUpdaterWorkflow {
   private readonly figmaClient: FigmaClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,15 @@ import path from 'node:path';
 
 import { loadConfig } from './config.js';
 import { logger } from './logger.js';
-import type { DiffMapping, GetDiffsOptions, LoadedConfig, VersionInfo } from './types.js';
+import type {
+  DiffMapping,
+  GetDiffsOptions,
+  LoadedConfig,
+  RunOptions,
+  RuntimeOptions,
+  VersionInfo,
+} from './types.js';
 import { FigmaUpdaterWorkflow } from './core/workflow.js';
-
-export interface RuntimeOptions {
-  cwd?: string;
-  directory?: string;
-}
-
-export interface RunOptions extends GetDiffsOptions, RuntimeOptions {
-  listOnly?: boolean;
-}
 
 async function createWorkflow(options: RuntimeOptions): Promise<FigmaUpdaterWorkflow> {
   const { cwd, directory } = options;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,14 @@
 import type { Version } from '@figma/rest-api-spec';
+import type { ElizaClient } from './core/eliza-client.js';
+import type { TranslationCatalog } from './core/translation-catalog.js';
+
+export interface CliFlags {
+  list?: boolean;
+  dir?: string;
+  old?: string;
+  new?: string;
+  cwd?: string;
+}
 
 export type DiffPair = Record<string, string>;
 export type DiffMapping = DiffPair[];
@@ -50,4 +60,70 @@ export interface GetDiffsOptions {
   figmaUrl: string;
   oldVersion?: string;
   newVersion?: string;
+}
+
+export interface RuntimeOptions {
+  cwd?: string;
+  directory?: string;
+}
+
+export interface RunOptions extends GetDiffsOptions, RuntimeOptions {
+  listOnly?: boolean;
+}
+
+export interface LoadConfigOptions {
+  cwd?: string;
+  /**
+   * Relative path to the configuration file. Defaults to `texts-updater-by-figma.config.js`.
+   */
+  configFile?: string;
+  /**
+   * Override the directory where files will be updated.
+   */
+  targetRoot?: string;
+}
+
+export interface VersionSelectionResult {
+  oldVersion: string;
+  newVersion: string;
+}
+
+export interface BuildDiffOptions {
+  figmaUrl: string;
+  oldVersion: string;
+  newVersion: string;
+}
+
+export interface FileRewriterOptions {
+  config: LoadedConfig;
+  translations: TranslationCatalog;
+  eliza: ElizaClient;
+}
+
+export interface ReplacementCandidate {
+  codePath: string;
+  searchText: string;
+}
+
+export interface ErrorLogOptions {
+  context?: string;
+}
+
+export type PromptResult = string[] | undefined | null;
+
+export interface ElizaResponse {
+  response?: {
+    choices?: Array<{
+      message?: {
+        content?: string;
+      };
+    }>;
+  };
+}
+
+export interface FetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
 }


### PR DESCRIPTION
## Summary
- move shared interfaces into src/types.ts and update consumers to import them
- trim logger helpers to keep only the essential error formatting logic

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd143713c8331a3375a878e06ecc9